### PR TITLE
fix: Hero Smiley Face Placement on Small Devices

### DIFF
--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -15,7 +15,7 @@ const Hero: FC = () => {
       >
         <div className="flex flex-col gap-6 md:gap-8 relative">
           <motion.div
-            className="absolute -top-20 right-2 md:-top-16 md:right-14"
+            className="absolute -top-10 sm:-top-20 right-2 md:-top-16 md:right-14"
             animate={{
               rotate: [-10, 10, -10],
             }}


### PR DESCRIPTION
## Description
This PR resolves the issue where the **animated smiley face** in the Hero section would go off-screen on smaller devices. The fix adjusts the placement of the smiley face to ensure it remains fully visible across all screen sizes, enhancing the user experience.